### PR TITLE
Add Support For Additional Header Parameters in HttpHelper

### DIFF
--- a/src/helpers/http/HttpHelper.ts
+++ b/src/helpers/http/HttpHelper.ts
@@ -10,7 +10,7 @@ import AccessToken, { AccessTokenResponse } from '../../models/utils/AccessToken
 class HttpClient<R, B> {
   client: AxiosInstance;
 
-  constructor(token: string, config?: {}) {
+  constructor(token: string, config?: Record<string, unknown>) {
     let header = {
       Authorization: `Bearer ${token}`,
       API_SERVICE_KEY: String(process.env.REACT_APP_DEV_API_SERVICE_KEY),
@@ -30,7 +30,7 @@ class HttpClient<R, B> {
     });
   }
 
-  public static async Create<R, B>(config?: {}): Promise<HttpClient<R, B>> {
+  public static async Create<R, B>(config?: Record<string, unknown>): Promise<HttpClient<R, B>> {
     const token = await HttpClient.getAccessToken();
     return new HttpClient<R, B>(token, config);
   }

--- a/src/helpers/http/HttpHelper.ts
+++ b/src/helpers/http/HttpHelper.ts
@@ -10,20 +10,29 @@ import AccessToken, { AccessTokenResponse } from '../../models/utils/AccessToken
 class HttpClient<R, B> {
   client: AxiosInstance;
 
-  constructor(token: string) {
+  constructor(token: string, config?: {}) {
+    let header = {
+      Authorization: `Bearer ${token}`,
+      API_SERVICE_KEY: String(process.env.REACT_APP_DEV_API_SERVICE_KEY),
+      JWT_TOKEN_KEY: String(process.env.REACT_APP_DEV_JWT_TOKEN_KEY),
+    };
+
+    if (config !== null) {
+      header = {
+        ...header,
+        ...config,
+      };
+    }
+
     this.client = axios.create({
       baseURL: HttpClient.getBaseURL(),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        API_SERVICE_KEY: String(process.env.REACT_APP_DEV_API_SERVICE_KEY),
-        JWT_TOKEN_KEY: String(process.env.REACT_APP_DEV_JWT_TOKEN_KEY),
-      },
+      headers: header,
     });
   }
 
-  public static async Create<R, B>(): Promise<HttpClient<R, B>> {
+  public static async Create<R, B>(config?: {}): Promise<HttpClient<R, B>> {
     const token = await HttpClient.getAccessToken();
-    return new HttpClient<R, B>(token);
+    return new HttpClient<R, B>(token, config);
   }
 
   get = async (URL: string): Promise<HttpResult<R>> => {


### PR DESCRIPTION
## Summary

This PR adds functionality to support additional header parameters in HttpClient

## What are the changes?

- Create method and contructor now accepts config as parameter.
- If config is not null, it is appended along with the header.
- This is then assigned to axios.create method

## PR Checklist

Please check your PR against the following requirements and update the check state accordingly.

#### General

- [x] Does this PR includes any breaking changes.
- [x] Have you self-reviewed this PR on context with the previous PR changes.
- [ ] Have you installed any node packages.
- [ ] Does the changes in this PR has any internal mocks set-up.

## References

- Task Id:
- Bug Id:
